### PR TITLE
Fix non-windows compile

### DIFF
--- a/lib/Runtime/Base/WindowsGlobalizationAdapter.cpp
+++ b/lib/Runtime/Base/WindowsGlobalizationAdapter.cpp
@@ -37,7 +37,9 @@ using namespace ABI::Windows::Foundation::Collections;
 #define IfFailedGoLabel(expr, label) if (FAILED(expr)) { goto label; }
 #define IfFailedGo(expr) IfFailedGoLabel(expr, LReturn)
 
+#ifdef _WIN32
 BOOL RoOriginateError(HRESULT error, HSTRING message) { return TRUE; }
+#endif
 
 namespace Js
 {


### PR DESCRIPTION
Keeps Windows 7 support while not breaking the other targets.